### PR TITLE
Add overview, architecture diagram, and example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,94 @@ This structured approach eliminates the chaos of prompt engineering and the tedi
 
 See examples/ for how to get started.
 
-```
-
 ## Installation
 ```bash
 npm install selvedge
 # or
 yarn add selvedge
-# or 
+# or
 bun add selvedge
+```
+
+## High-level overview
+
+Selvedge is a TypeScript-first DSL that wraps the moving parts of LLM applications—prompt templates, typed schemas, model routing, and orchestration—behind a single `selvedge` namespace. Core capabilities include:
+
+- **Typed prompts** via helpers in `lib/prompts` and `lib/schema`, making model inputs and outputs explicit.
+- **Programs** that generate and execute code from specifications in `lib/programs`, allowing intent-driven automation.
+- **Flows** that compose prompts, transforms, validators, and filters from `lib/flow` into reusable pipelines.
+- **Model registry and providers** in `lib/models` and `lib/providers` to register OpenAI, Anthropic, or mock backends with friendly aliases.
+- **Optimization** helpers (e.g., few-shot tuning) in `lib/optimize` to iteratively improve prompts.
+- **Storage and management** layers in `lib/storage` and `lib/manager` for sharing state and coordinating runs.
+
+### Architecture at a glance
+
+The library layers are small and composable. At runtime you usually interact with the merged `selvedge` export from `src/index.ts`, while each subsystem stays focused on a single responsibility:
+
+```
+                             +--------------------+
+                             |  selvedge namespace|
+                             |  (src/index.ts)    |
+                             +---------+----------+
+                                       |
+           +---------------------------+----------------------------+
+           |                            |                           |
+    +------+------+            +--------+--------+          +-------+-------+
+    | Prompts &   |            | Programs &      |          | Flow engine   |
+    | Schemas     |            | Optimizers      |          | (lib/flow)    |
+    | (lib/prompts|            | (lib/programs,  |          | compose steps |
+    |  lib/schema)|            |  lib/optimize)  |          | & run filters)|
+    +------+------+            +--------+--------+          +-------+-------+
+           |                            |                           |
+           +----------------------------+---------------------------+
+                                       |
+                               +-------+-------+
+                               | Model registry|
+                               | (lib/models & |
+                               |  providers)   |
+                               +-------+-------+
+                                       |
+                               +-------+-------+
+                               | Storage &     |
+                               | Manager       |
+                               | (lib/storage, |
+                               |  lib/manager) |
+                               +---------------+
+```
+
+### Common use cases
+
+- Building **structured generation** features where LLM outputs must conform to typed schemas.
+- Creating **multi-step reasoning pipelines** that validate, branch, or filter intermediate results.
+- Prototyping **agentic behaviors** by turning high-level specifications into executable programs.
+- Running **A/B experiments or prompt optimizations** with interchangeable model backends.
+- Developing **tests and mocks** for LLM-dependent code paths via the mock provider.
+
+### Quick example
+
+```ts
+import selvedge from "selvedge";
+
+// 1) Register models
+selvedge.models({
+  fast: selvedge.openai("gpt-4o-mini"),
+  smart: selvedge.anthropic("claude-3-opus"),
+});
+
+// 2) Define a typed prompt template
+const summarize = selvedge.prompt<{ text: string }, { bullets: string[] }>`
+Summarize the following article into 3 bullet points.
+Text: {{text}}
+Return JSON with a "bullets" array of strings.
+`;
+
+// 3) Compose a flow with validation
+const pipeline = selvedge.flow([
+  summarize,
+  selvedge.validate(({ bullets }) => Array.isArray(bullets) && bullets.length === 3),
+]);
+
+// 4) Run the flow against a registered model
+const result = await pipeline({ text: "Long-form content" }, { model: "fast" });
+console.log(result.bullets);
 ```


### PR DESCRIPTION
## Summary
- add high-level overview of Selvedge capabilities and layers
- include an ASCII architecture diagram and common use cases
- provide a quickstart example showing model registration, prompt definition, and flow execution

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69338bc0a4ac8324be169cd21a045237)